### PR TITLE
withoutTrailingSlash

### DIFF
--- a/components/nav.js
+++ b/components/nav.js
@@ -3,7 +3,7 @@ import Link from 'next/link'
 
 const links = [
   { href: 'https://zeit.co/now', label: 'ZEIT' },
-  { href: 'https://github.com/zeit/next.js', label: 'GitHub' },
+  { href: '/about/', label: 'About' },
 ].map(link => {
   link.key = `nav-link-${link.href}-${link.label}`
   return link

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,0 +1,24 @@
+import Error from "next/error";
+import Router from "next/router";
+
+export default Error;
+
+Error.getInitialProps = ({ res, err, asPath }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+
+  if (statusCode && statusCode === 404) {
+    if (asPath.match(/\/$/)) {
+      const withoutTrailingSlash = asPath.substr(0, asPath.length - 1);
+      if (res) {
+        res.writeHead(302, {
+          Location: withoutTrailingSlash
+        });
+        res.end();
+      } else {
+        Router.push(withoutTrailingSlash);
+      }
+    }
+  }
+
+  return { statusCode };
+};


### PR DESCRIPTION
`/about/` へのアクセスが 404 になるので、 `/about` に 302 redirect するサンプル
https://github.com/zeit/next.js/issues/5214#issuecomment-564724632